### PR TITLE
Made `astunparse` de-facto non-mandatory

### DIFF
--- a/peval/components/peval_function_header.py
+++ b/peval/components/peval_function_header.py
@@ -6,8 +6,6 @@ from peval.tools import replace_fields, ast_walker, ImmutableDict
 from peval.core.expression import peval_expression
 from peval.typing import ConstsDictT, PassOutputT
 
-from astunparse import dump
-
 
 @ast_walker
 class _peval_function_header:

--- a/peval/core/function.py
+++ b/peval/core/function.py
@@ -10,8 +10,6 @@ from types import FunctionType
 from collections import OrderedDict
 from typing import Union, Optional, Callable, List, Iterable, Set
 
-import astunparse
-
 from peval.tools import unindent, replace_fields, ImmutableADict, ast_inspector, ast_transformer
 from peval.core.gensym import GenSym
 from peval.core.reify import reify_unwrapped
@@ -267,7 +265,18 @@ class Function:
         """
         Generates the function's source code based on its tree.
         """
-        return astunparse.unparse(self.tree)
+
+        try:
+            from ast import unparse
+        except ImportError:
+            try:
+                from astunparse import unparse
+            except ImportError:
+                from astor import to_source as unparse
+        else:
+            ast.fix_missing_locations(self.tree)
+
+        return unparse(self.tree)
 
     @classmethod
     def from_object(cls, func: Callable, ignore_decorators: bool = False) -> "Function":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 urls = {Homepage = "https://github.com/fjarri/peval"}
 requires-python = ">=3.8.0"
 dependencies = [
-    "astunparse>=1.3",
+    'astunparse>=1.3; python_version <= "3.9"',
     "typing-extensions>=4.2",
 ]
 dynamic = ["version"]

--- a/tests/test_core/test_function.py
+++ b/tests/test_core/test_function.py
@@ -1,8 +1,6 @@
 import ast
 import copy
 import sys
-
-import astunparse
 import inspect
 
 from peval.core.function import Function
@@ -315,15 +313,26 @@ def test_get_source():
     function = Function.from_object(sample_fn)
     source = normalize_source(function.get_source())
 
-    expected_source = unindent(
-        """
-        def sample_fn(x, y, foo='bar', **kw):
-            if (foo == 'bar'):
-                return (x + y)
-            else:
-                return kw['zzz']
-        """
-    )
+    if "unparse" in ast.__dict__ or "astor" in sys.modules:
+        expected_source = unindent(
+            """
+            def sample_fn(x, y, foo='bar', **kw):
+                if foo == 'bar':
+                    return x + y
+                else:
+                    return kw['zzz']
+            """
+        )
+    else:
+        expected_source = unindent(
+            """
+            def sample_fn(x, y, foo='bar', **kw):
+                if (foo == 'bar'):
+                    return (x + y)
+                else:
+                    return kw['zzz']
+            """
+        )
 
     assert source == expected_source
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,11 +2,29 @@ from __future__ import print_function
 
 import ast
 import difflib
+from ast import dump
 
-from astunparse import unparse, dump
-
-from peval.tools import unindent, ast_equal
+from peval.tools import ast_equal, unindent
 from peval.core.function import Function
+
+try:
+    # raise ImportError
+    from ast import fix_missing_locations
+    from ast import unparse as _unparse
+except ImportError:
+    from astunparse import unparse
+
+    def _if_expr(a, b):
+        return "if (" + str(a) + " > " + str(b) + "):"
+
+else:
+
+    def _if_expr(a, b):
+        return "if " + str(a) + " > " + str(b) + ":"
+
+    def unparse(n):
+        fix_missing_locations(n)
+        return _unparse(n)
 
 
 def normalize_source(source):


### PR DESCRIPTION
* When `peval` is used for optimization purposes, since it is used only in 1 place.
* Made `astunparse` completely unneeded when Python >=3.9 is used (since it has `ast.unparse`).
* Allowed nit to fail if `astor` is installed, since it can be used instead of `astunparse`.