### PR TITLE
Astunparse optional

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,60 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
-
+  test-astunparse:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8"]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install .[tests,astunparse]
+    - name: Test with pytest
+      run: |
+        py.test --cov=peval --cov-report=xml tests
+    - name: Upload coverage
+      run: |
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov
 
+  test-astor:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8"]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install .[tests,astor]
+    - name: Test with pytest
+      run: |
+        py.test --cov=peval --cov-report=xml tests
+    - name: Upload coverage
+      run: |
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/peval/components/peval_function_header.py
+++ b/peval/components/peval_function_header.py
@@ -6,8 +6,6 @@ from peval.tools import replace_fields, ast_walker, ImmutableDict
 from peval.core.expression import peval_expression
 from peval.typing import ConstsDictT, PassOutputT
 
-from astunparse import dump
-
 
 @ast_walker
 class _peval_function_header:

--- a/peval/core/function.py
+++ b/peval/core/function.py
@@ -10,8 +10,6 @@ from types import FunctionType
 from collections import OrderedDict
 from typing import Union, Optional, Callable, List, Iterable, Set
 
-import astunparse
-
 from peval.tools import unindent, replace_fields, ImmutableADict, ast_inspector, ast_transformer
 from peval.core.gensym import GenSym
 from peval.core.reify import reify_unwrapped
@@ -267,7 +265,18 @@ class Function:
         """
         Generates the function's source code based on its tree.
         """
-        return astunparse.unparse(self.tree)
+
+        try:
+            from ast import unparse
+        except ImportError:
+            try:
+                from astunparse import unparse
+            except ImportError:
+                from astor import to_source as unparse
+        else:
+            ast.fix_missing_locations(self.tree)
+
+        return unparse(self.tree)
 
     @classmethod
     def from_object(cls, func: Callable, ignore_decorators: bool = False) -> "Function":

--- a/peval/core/function.py
+++ b/peval/core/function.py
@@ -10,7 +10,14 @@ from types import FunctionType
 from collections import OrderedDict
 from typing import Union, Optional, Callable, List, Iterable, Set
 
-from peval.tools import unindent, replace_fields, ImmutableADict, ast_inspector, ast_transformer
+from peval.tools import (
+    unparse,
+    unindent,
+    replace_fields,
+    ImmutableADict,
+    ast_inspector,
+    ast_transformer,
+)
 from peval.core.gensym import GenSym
 from peval.core.reify import reify_unwrapped
 from peval.core.scope import analyze_scope
@@ -233,6 +240,11 @@ class Function:
         compiler_flags: int,
     ) -> None:
 
+        # TODO: write our own implementation that does not mutate the tree,
+        # and reuses existing nodes. For now we have to make a copy.
+        tree = copy.deepcopy(tree)
+        ast.fix_missing_locations(tree)
+
         self.tree = tree
         self.globals = globals_
         self.closure_vals = closure_vals
@@ -265,17 +277,6 @@ class Function:
         """
         Generates the function's source code based on its tree.
         """
-
-        try:
-            from ast import unparse
-        except ImportError:
-            try:
-                from astunparse import unparse
-            except ImportError:
-                from astor import to_source as unparse
-        else:
-            ast.fix_missing_locations(self.tree)
-
         return unparse(self.tree)
 
     @classmethod

--- a/peval/tools/__init__.py
+++ b/peval/tools/__init__.py
@@ -1,4 +1,4 @@
 from peval.tools.dispatcher import Dispatcher
 from peval.tools.immutable import ImmutableDict, ImmutableADict
-from peval.tools.utils import unindent, replace_fields, ast_equal, map_accum, fold_and
+from peval.tools.utils import unparse, unindent, replace_fields, ast_equal, map_accum, fold_and
 from peval.tools.walker import ast_walker, ast_inspector, ast_transformer

--- a/peval/tools/utils.py
+++ b/peval/tools/utils.py
@@ -1,7 +1,35 @@
 import ast
 import re
+import sys
 from typing import Callable, Any, Iterable, Tuple, Sequence, Union, TypeVar, List, Dict, cast
 from typing_extensions import ParamSpec, Concatenate
+
+
+def unparse(tree: ast.AST) -> str:
+    if sys.version_info >= (3, 9):
+        return ast.unparse(tree)
+
+    # TODO: as long as we're supporting Python 3.8 we have to rely on third-party unparsers.
+    # Clean it up when Py3.8 is dropped.
+
+    # Enabled by the `astunparse` feature.
+    try:
+        import astunparse
+
+        return astunparse.unparse(tree)
+    except ImportError:
+        pass
+
+    # Enabled by the `astor` feature.
+    try:
+        import astor
+
+        return astor.to_source(tree)
+    except ImportError as exc:
+        raise ImportError(
+            "Unparsing functionality is not available; switch to Python 3.9+, "
+            "install with 'astunparse' feature, or install with 'astor' feature."
+        ) from exc
 
 
 def unindent(source: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 urls = {Homepage = "https://github.com/fjarri/peval"}
 requires-python = ">=3.8.0"
 dependencies = [
-    "astunparse>=1.3",
+    'astunparse>=1.3; python_version <= "3.9"',
     "typing-extensions>=4.2",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,17 @@ classifiers = [
 urls = {Homepage = "https://github.com/fjarri/peval"}
 requires-python = ">=3.8.0"
 dependencies = [
-    'astunparse>=1.3; python_version <= "3.9"',
     "typing-extensions>=4.2",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
+astunparse = [
+    "astunparse>=1.3",
+]
+astor = [
+    "astor>=0.8",
+]
 tests = [
     "pytest>=7",
     "pytest-cov",

--- a/tests/test_core/test_cfg.py
+++ b/tests/test_core/test_cfg.py
@@ -2,11 +2,20 @@ import ast
 import inspect
 import os, os.path
 import subprocess
+import sys
 
+from peval.tools import unparse
 from peval.core.cfg import build_cfg
-from tests.utils import _if_expr, print_diff, unparse
+from tests.utils import print_diff, unparser
 
 RENDER_GRAPHS = False
+
+
+def _if_expr(a, b):
+    if unparser() == "astunparse":
+        return f"if ({a} > {b}):"
+    else:
+        return f"if {a} > {b}:"
 
 
 def make_label(node):
@@ -32,7 +41,6 @@ def get_labeled_edges(cfg):
             continue
         visited.add(src_id)
 
-        print(ast.dump(cfg.graph.nodes[src_id].ast_node))
         src_label = make_label(cfg.graph.nodes[src_id])
 
         dests = [

--- a/tests/test_core/test_function.py
+++ b/tests/test_core/test_function.py
@@ -1,8 +1,6 @@
 import ast
 import copy
 import sys
-
-import astunparse
 import inspect
 
 from peval.core.function import Function
@@ -315,15 +313,26 @@ def test_get_source():
     function = Function.from_object(sample_fn)
     source = normalize_source(function.get_source())
 
-    expected_source = unindent(
-        """
-        def sample_fn(x, y, foo='bar', **kw):
-            if (foo == 'bar'):
-                return (x + y)
-            else:
-                return kw['zzz']
-        """
-    )
+    if "unparse" in ast.__dict__ or "astor" in sys.modules:
+        expected_source = unindent(
+            """
+            def sample_fn(x, y, foo='bar', **kw):
+                if foo == 'bar':
+                    return x + y
+                else:
+                    return kw['zzz']
+            """
+        )
+    else:
+        expected_source = unindent(
+            """
+            def sample_fn(x, y, foo='bar', **kw):
+                if (foo == 'bar'):
+                    return (x + y)
+                else:
+                    return kw['zzz']
+            """
+        )
 
     assert source == expected_source
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,11 +2,29 @@ from __future__ import print_function
 
 import ast
 import difflib
+from ast import dump
 
-from astunparse import unparse, dump
-
-from peval.tools import unindent, ast_equal
+from peval.tools import ast_equal, unindent
 from peval.core.function import Function
+
+try:
+    # raise ImportError
+    from ast import fix_missing_locations
+    from ast import unparse as _unparse
+except ImportError:
+    from astunparse import unparse
+
+    def _if_expr(a, b):
+        return "if (" + str(a) + " > " + str(b) + "):"
+
+else:
+
+    def _if_expr(a, b):
+        return "if " + str(a) + " > " + str(b) + ":"
+
+    def unparse(n):
+        fix_missing_locations(n)
+        return _unparse(n)
 
 
 def normalize_source(source):


### PR DESCRIPTION
Supersedes #10 - rearranged the code a little to make the unparser separation more maintainable.

The user now has a choice of:
- not installing third-party unparsers (so any unparsing attempt will fail in Py<3.9)
- installing `astunparse`
- installing `astor`