### PR TITLE
Astunparse optional

### DIFF
--- a/peval/tools/utils.py
+++ b/peval/tools/utils.py
@@ -5,31 +5,28 @@ from typing import Callable, Any, Iterable, Tuple, Sequence, Union, TypeVar, Lis
 from typing_extensions import ParamSpec, Concatenate
 
 
-def unparse(tree: ast.AST) -> str:
-    if sys.version_info >= (3, 9):
-        return ast.unparse(tree)
-
+try:
+    from ast import unparse
+except ImportError:
     # TODO: as long as we're supporting Python 3.8 we have to rely on third-party unparsers.
     # Clean it up when Py3.8 is dropped.
 
     # Enabled by the `astunparse` feature.
     try:
-        import astunparse
-
-        return astunparse.unparse(tree)
+        from astunparse import unparse
     except ImportError:
-        pass
+        # Enabled by the `astor` feature.
+        try:
+            import astor
 
-    # Enabled by the `astor` feature.
-    try:
-        import astor
+            def unparse(tree: ast.AST) -> str:
+                return astor.to_source(tree)
 
-        return astor.to_source(tree)
-    except ImportError as exc:
-        raise ImportError(
-            "Unparsing functionality is not available; switch to Python 3.9+, "
-            "install with 'astunparse' feature, or install with 'astor' feature."
-        ) from exc
+        except ImportError as exc:
+            raise ImportError(
+                "Unparsing functionality is not available; switch to Python 3.9+, "
+                "install with 'astunparse' feature, or install with 'astor' feature."
+            ) from exc
 
 
 def unindent(source: str) -> str:

--- a/peval/tools/utils.py
+++ b/peval/tools/utils.py
@@ -1,32 +1,52 @@
 import ast
 import re
-import sys
-from typing import Callable, Any, Iterable, Tuple, Sequence, Union, TypeVar, List, Dict, cast
+from typing import (
+    Callable,
+    Any,
+    Iterable,
+    Optional,
+    Tuple,
+    Sequence,
+    Union,
+    TypeVar,
+    List,
+    Dict,
+    cast,
+)
 from typing_extensions import ParamSpec, Concatenate
 
 
-try:
-    from ast import unparse
-except ImportError:
-    # TODO: as long as we're supporting Python 3.8 we have to rely on third-party unparsers.
-    # Clean it up when Py3.8 is dropped.
+# TODO: as long as we're supporting Python 3.8 we have to rely on third-party unparsers.
+# Clean it up when Py3.8 is dropped.
 
+_unparse = None
+
+try:
+    from ast import unparse as _unparse  # type: ignore
+except ImportError:
+    pass
+
+if _unparse is None:
     # Enabled by the `astunparse` feature.
     try:
-        from astunparse import unparse
+        from astunparse import unparse as _unparse  # type: ignore
     except ImportError:
-        # Enabled by the `astor` feature.
-        try:
-            import astor
+        pass
 
-            def unparse(tree: ast.AST) -> str:
-                return astor.to_source(tree)
+if _unparse is None:
+    # Enabled by the `astor` feature.
+    try:
+        from astor import to_source as _unparse  # type: ignore
+    except ImportError:
+        pass
 
-        except ImportError as exc:
-            raise ImportError(
-                "Unparsing functionality is not available; switch to Python 3.9+, "
-                "install with 'astunparse' feature, or install with 'astor' feature."
-            ) from exc
+if _unparse is None:
+    raise ImportError(
+        "Unparsing functionality is not available; switch to Python 3.9+, "
+        "install with 'astunparse' feature, or install with 'astor' feature."
+    )
+
+unparse = cast(Callable[[ast.AST], str], _unparse)
 
 
 def unindent(source: str) -> str:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,7 @@ from peval.tools import ast_equal, unindent, unparse
 from peval.core.function import Function
 
 
-def _unparser() -> str:
+def unparser() -> str:
 
     # Different unparsers we use render some nodes differently.
     # For example, `astunparse` encloses logical expressions in parentheses when unparsing,
@@ -19,28 +19,30 @@ def _unparser() -> str:
     # follows the logic in `tools.utils.unparse()`
     try:
         from ast import unparse
-    except ImportError:
-        try:
-            import astunparse
 
-            return "astunparse"
-        except ImportError:
-            pass
-
-        try:
-            import astor
-
-            return "astor"
-        except Exception:
-            raise
-
-    else:
         return "ast"
+    except ImportError:
+        pass
 
-def unparser() -> str:
-    res = _unparser()
-    print(res)
-    return res
+    try:
+        from astunparse import unparse
+
+        return "astunparse"
+    except ImportError:
+        pass
+
+    try:
+        from astor import to_source
+
+        return "astor"
+    except ImportError:
+        pass
+
+    raise ImportError(
+        "Unparsing functionality is not available; switch to Python 3.9+, "
+        "install with 'astunparse' feature, or install with 'astor' feature."
+    )
+
 
 def normalize_source(source):
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,7 @@ from peval.tools import ast_equal, unindent, unparse
 from peval.core.function import Function
 
 
-def unparser() -> str:
+def _unparser() -> str:
 
     # Different unparsers we use render some nodes differently.
     # For example, `astunparse` encloses logical expressions in parentheses when unparsing,
@@ -17,7 +17,9 @@ def unparser() -> str:
     # we need this compatibility stub, because some tests check the unparsed source.
 
     # follows the logic in `tools.utils.unparse()`
-    if sys.version_info < (3, 9):
+    try:
+        from ast import unparse
+    except ImportError:
         try:
             import astunparse
 
@@ -35,6 +37,10 @@ def unparser() -> str:
     else:
         return "ast"
 
+def unparser() -> str:
+    res = _unparser()
+    print(res)
+    return res
 
 def normalize_source(source):
 


### PR DESCRIPTION
Additions to #13

- Flattened the import logic
- Removed a debug print
- Added the typing annotation for `unparse()` to make `mypy` happy (have to force it, since `mypy` can't propagate types with possibly failing imports). Also saves us the hassle of adding typing stubs for `astunparse` and `astor`. 